### PR TITLE
Add method to get number as string

### DIFF
--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,0 +1,15 @@
+<?php
+/*
+ * This file is part of the PayBreak/basket package.
+ *
+ * (c) PayBreak <dev@paybreak.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PayBreak\Luhn;
+
+class Exception extends \Exception
+{
+}

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -10,6 +10,11 @@
 
 namespace PayBreak\Luhn;
 
+/**
+ * Exception
+ *
+ * @author WN
+ */
 class Exception extends \Exception
 {
 }

--- a/src/Luhn.php
+++ b/src/Luhn.php
@@ -38,7 +38,7 @@ class Luhn
      */
     public static function generateNumber($number)
     {
-        if ($number > PHP_INT_MAX && $number <= 0) {
+        if ($number > PHP_INT_MAX || $number <= 0) {
             throw new Exception('Given value is out of bounds');
         }
 

--- a/src/Luhn.php
+++ b/src/Luhn.php
@@ -38,21 +38,36 @@ class Luhn
      */
     public static function generateNumber($number)
     {
-        return (int) ($number . self::checksum($number));
+        if ($number > PHP_INT_MAX && $number <= 0) {
+            throw new Exception('Given value is out of bounds');
+        }
+
+        $result = self::generateString($number);
+
+        if ($result > PHP_INT_MAX) {
+            throw new Exception('Result is out of bounds for integer type');
+        }
+
+        return (int) $result;
     }
 
     /**
-     * @param $number
+     * @author CG
+     * @param int|float|string $number
      * @return string
      */
     public static function generateString($number)
     {
+        if (!is_numeric($number)) {
+            throw new Exception('Given value is not numeric');
+        }
+
         return ($number . self::checksum($number));
     }
 
     /**
      * @author WN
-     * @param int|string $number
+     * @param int|float|string $number
      * @param bool $check Set to true if you are calculating checksum for validation
      * @return int
      */

--- a/src/Luhn.php
+++ b/src/Luhn.php
@@ -42,8 +42,17 @@ class Luhn
     }
 
     /**
+     * @param $number
+     * @return string
+     */
+    public static function generateString($number)
+    {
+        return ($number . self::checksum($number));
+    }
+
+    /**
      * @author WN
-     * @param int $number
+     * @param int|string $number
      * @param bool $check Set to true if you are calculating checksum for validation
      * @return int
      */

--- a/src/Luhn.php
+++ b/src/Luhn.php
@@ -42,7 +42,7 @@ class Luhn
             throw new Exception('Given value is out of bounds');
         }
 
-        $result = self::generateString($number);
+        $result = self::generateString((int) $number);
 
         if ($result > PHP_INT_MAX) {
             throw new Exception('Result is out of bounds for integer type');
@@ -53,13 +53,13 @@ class Luhn
 
     /**
      * @author CG
-     * @param int|float|string $number
+     * @param int|string $number
      * @return string
      */
     public static function generateString($number)
     {
-        if (!is_numeric($number)) {
-            throw new Exception('Given value is not numeric');
+        if (!preg_match('/^\d+$/', $number)) {
+            throw new Exception('Given value is not integer representation');
         }
 
         return ($number . self::checksum($number));
@@ -67,7 +67,7 @@ class Luhn
 
     /**
      * @author WN
-     * @param int|float|string $number
+     * @param int|string $number
      * @param bool $check Set to true if you are calculating checksum for validation
      * @return int
      */

--- a/tests/LuhnTest.php
+++ b/tests/LuhnTest.php
@@ -18,7 +18,29 @@ class LuhnTest extends PHPUnit_Framework_TestCase
     public function testGenerateNumber()
     {
         $this->assertInternalType('int', \PayBreak\Luhn\Luhn::generateNumber(12345));
+        $this->assertInternalType('int', \PayBreak\Luhn\Luhn::generateNumber(12345.00));
         $this->assertGreaterThan(123, \PayBreak\Luhn\Luhn::generateNumber(123));
+
+        $this->assertInternalType('int', \PayBreak\Luhn\Luhn::generateNumber(12345E+12));
+        $this->assertSame(12302, \PayBreak\Luhn\Luhn::generateNumber(1.23E+3));
+    }
+
+    public function testGenerateNumberFailParam()
+    {
+        $this->setExpectedException(PayBreak\Luhn\Exception::class, 'Given value is out of bounds');
+        \PayBreak\Luhn\Luhn::generateNumber(PHP_INT_MAX * 2);
+    }
+
+    public function testGenerateNumberFailNegative()
+    {
+        $this->setExpectedException(PayBreak\Luhn\Exception::class, 'Given value is out of bounds');
+        \PayBreak\Luhn\Luhn::generateNumber(-2);
+    }
+
+    public function testGenerateNumberFailResult()
+    {
+        $this->setExpectedException(PayBreak\Luhn\Exception::class, 'Result is out of bounds for integer type');
+        \PayBreak\Luhn\Luhn::generateNumber(PHP_INT_MAX - 4);
     }
 
     public function testValidateNumber()
@@ -32,5 +54,15 @@ class LuhnTest extends PHPUnit_Framework_TestCase
     {
         $this->assertInternalType('string', \PayBreak\Luhn\Luhn::generateString('35145120840121'));
         $this->assertSame('351451208401216', \PayBreak\Luhn\Luhn::generateString('35145120840121'));
+        $this->assertSame(
+            '35145120843454656553423455674565301212',
+            \PayBreak\Luhn\Luhn::generateString('3514512084345465655342345567456530121')
+        );
+    }
+
+    public function testGenerateStringFailResult()
+    {
+        $this->setExpectedException(PayBreak\Luhn\Exception::class, 'Given value is not integer representation');
+        \PayBreak\Luhn\Luhn::generateString('234.67');
     }
 }

--- a/tests/LuhnTest.php
+++ b/tests/LuhnTest.php
@@ -27,4 +27,10 @@ class LuhnTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(\PayBreak\Luhn\Luhn::validateNumber(16416612));
         $this->assertFalse(\PayBreak\Luhn\Luhn::validateNumber(16416610));
     }
+
+    public function testGenerateString()
+    {
+        $this->assertInternalType('string', \PayBreak\Luhn\Luhn::generateString('35145120840121'));
+        $this->assertSame('351451208401216', \PayBreak\Luhn\Luhn::generateString('35145120840121'));
+    }
 }


### PR DESCRIPTION
The `generateNumber` method does not work on systems where the result of the Luhn algorithm calculation is a number that is greater than `PHP_INT_MAX`. This is because the string that results from combining the supplied number with the checksum is cast to an integer, which if it exceeds `PHP_INT_MAX` is changed to the maximum integer.

This has been solved by adding a `generateString` method that avoids casting the result of the Luhn algorithm to an integer.

I've also added a test for the `generateString` method.